### PR TITLE
Support for exceptions with multiple fields

### DIFF
--- a/src/main/java/com/coveo/feign/ReflectionErrorDecoder.java
+++ b/src/main/java/com/coveo/feign/ReflectionErrorDecoder.java
@@ -59,16 +59,11 @@ public abstract class ReflectionErrorDecoder<T, S extends Exception> implements 
   private Decoder decoder = new JacksonDecoder();
   private ErrorDecoder fallbackErrorDecoder = new ErrorDecoder.Default();
 
-  private boolean isMultipleFieldsEnabled;
+  private boolean isMultipleFieldsEnabled = false;
 
   public ReflectionErrorDecoder(
       Class<?> apiClass, Class<T> apiResponseClass, Class<S> baseExceptionClass) {
     this(apiClass, apiResponseClass, baseExceptionClass, "");
-  }
-
-  public ReflectionErrorDecoder(
-          Class<?> apiClass, Class<T> apiResponseClass, Class<S> baseExceptionClass, boolean isMultipleFieldsEnabled) {
-    this(apiClass, apiResponseClass, baseExceptionClass, "", isMultipleFieldsEnabled);
   }
 
   public ReflectionErrorDecoder(
@@ -91,23 +86,6 @@ public abstract class ReflectionErrorDecoder<T, S extends Exception> implements 
       Class<T> apiResponseClass,
       Class<S> baseExceptionClass,
       String basePackage,
-      boolean isMultipleFieldsEnabled) {
-    this(
-        apiClass,
-        apiResponseClass,
-        baseExceptionClass,
-        basePackage,
-        ClassUtils.isSpringFrameworkAvailable()
-            ? new CachedSpringClassHierarchySupplier(baseExceptionClass, basePackage)
-            : new EmptyClassHierarchySupplier(),
-        isMultipleFieldsEnabled);
-  }
-
-  public ReflectionErrorDecoder(
-      Class<?> apiClass,
-      Class<T> apiResponseClass,
-      Class<S> baseExceptionClass,
-      String basePackage,
       ClassHierarchySupplier classHierarchySupplier) {
     this.apiClass = apiClass;
     this.apiResponseClass = apiResponseClass;
@@ -118,21 +96,8 @@ public abstract class ReflectionErrorDecoder<T, S extends Exception> implements 
     initialize();
   }
 
-  public ReflectionErrorDecoder(
-          Class<?> apiClass,
-          Class<T> apiResponseClass,
-          Class<S> baseExceptionClass,
-          String basePackage,
-          ClassHierarchySupplier classHierarchySupplier,
-          boolean isMultipleFieldsEnabled) {
-    this.apiClass = apiClass;
-    this.apiResponseClass = apiResponseClass;
-    this.basePackage = basePackage;
-    this.classHierarchySupplier = classHierarchySupplier;
-    this.baseExceptionClass = baseExceptionClass;
+  public void setMultipleFieldsEnabled(boolean isMultipleFieldsEnabled) {
     this.isMultipleFieldsEnabled = isMultipleFieldsEnabled;
-
-    initialize();
   }
 
   //The copied response will be closed in SynchronousMethodHandler and the actual is closed in Util.toByteArray

--- a/src/main/java/com/coveo/feign/ReflectionErrorDecoder.java
+++ b/src/main/java/com/coveo/feign/ReflectionErrorDecoder.java
@@ -58,7 +58,6 @@ public abstract class ReflectionErrorDecoder<T, S extends Exception> implements 
   private Map<String, ThrownExceptionDetails<RuntimeException>> runtimeExceptionsThrown =
       new HashMap<>();
 
-  private ObjectMapper objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
   private Decoder decoder = new JacksonDecoder();
   private ErrorDecoder fallbackErrorDecoder = new ErrorDecoder.Default();
 
@@ -191,7 +190,7 @@ public abstract class ReflectionErrorDecoder<T, S extends Exception> implements 
 
   private S getExceptionByObjectMapperAndReflection(String exceptionKey, T apiResponse, Response response)
           throws IllegalArgumentException, IllegalAccessException, IOException {
-    S exceptionToBeThrown = objectMapper.readValue(response.body().asInputStream(), exceptionsThrown.get(exceptionKey).getClazz());
+    S exceptionToBeThrown = (S) decoder.decode(response, exceptionsThrown.get(exceptionKey).getClazz());
     detailMessageField.set(exceptionToBeThrown, getMessageFromResponse(apiResponse));
     return exceptionToBeThrown;
   }

--- a/src/main/java/com/coveo/feign/ReflectionErrorDecoder.java
+++ b/src/main/java/com/coveo/feign/ReflectionErrorDecoder.java
@@ -126,7 +126,6 @@ public abstract class ReflectionErrorDecoder<T, S extends Exception> implements 
           IllegalAccessException | IllegalArgumentException | InstantiationException
                   | InvocationTargetException
               e) {
-
         logger.error(
             "Error instantiating the exception declared thrown for the interface '{}'",
             apiClass.getName(),

--- a/src/test/java/com/coveo/feign/ReflectionErrorDecoderTest.java
+++ b/src/test/java/com/coveo/feign/ReflectionErrorDecoderTest.java
@@ -277,9 +277,10 @@ public class ReflectionErrorDecoderTest {
   @Test
   public void testMultipleFieldsException() throws Exception {
     ServiceExceptionErrorDecoder errorDecoder =
-            new ServiceExceptionErrorDecoder(TestApiWithExceptionsWithMultipleFields.class, true);
-    Map<String, Object> responseAsMap = new HashMap<>();
+            new ServiceExceptionErrorDecoder(TestApiWithExceptionsWithMultipleFields.class);
+    errorDecoder.setMultipleFieldsEnabled(true);
 
+    Map<String, Object> responseAsMap = new HashMap<>();
     responseAsMap.put("errorCode", MultipleFieldsException.ERROR_CODE);
     responseAsMap.put("message", DUMMY_MESSAGE);
     responseAsMap.put("field1", 1);

--- a/src/test/java/com/coveo/feign/ReflectionErrorDecoderTest.java
+++ b/src/test/java/com/coveo/feign/ReflectionErrorDecoderTest.java
@@ -47,6 +47,7 @@ import com.coveo.feign.ReflectionErrorDecoderTestClasses.TestApiWithExceptionsNo
 import com.coveo.feign.ReflectionErrorDecoderTestClasses.TestApiWithExceptionsWithInvalidConstructor;
 import com.coveo.feign.ReflectionErrorDecoderTestClasses.TestApiWithExceptionsWithMultipleConstructors;
 import com.coveo.feign.ReflectionErrorDecoderTestClasses.TestApiWithExceptionsWithMultipleConstructorsWithOnlyThrowables;
+import com.coveo.feign.ReflectionErrorDecoderTestClasses.TestApiWithExceptionsWithMultipleFields;
 import com.coveo.feign.ReflectionErrorDecoderTestClasses.TestApiWithMethodsNotAnnotated;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -114,8 +115,7 @@ public class ReflectionErrorDecoderTest {
             ExceptionWithTwoStringsConstructorException.ERROR_CODE,
             ExceptionWithThrowableConstructorException.ERROR_CODE,
             ExceptionWithStringAndThrowableConstructorException.ERROR_CODE,
-            ExceptionWithExceptionConstructorException.ERROR_CODE,
-            MultipleFieldsException.ERROR_CODE));
+            ExceptionWithExceptionConstructorException.ERROR_CODE));
   }
 
   @Test
@@ -277,7 +277,7 @@ public class ReflectionErrorDecoderTest {
   @Test
   public void testMultipleFieldsException() throws Exception {
     ServiceExceptionErrorDecoder errorDecoder =
-            new ServiceExceptionErrorDecoder(TestApiClassWithPlainExceptions.class, true);
+            new ServiceExceptionErrorDecoder(TestApiWithExceptionsWithMultipleFields.class, true);
     Map<String, Object> responseAsMap = new HashMap<>();
 
     responseAsMap.put("errorCode", MultipleFieldsException.ERROR_CODE);

--- a/src/test/java/com/coveo/feign/ReflectionErrorDecoderTest.java
+++ b/src/test/java/com/coveo/feign/ReflectionErrorDecoderTest.java
@@ -114,7 +114,8 @@ public class ReflectionErrorDecoderTest {
             ExceptionWithTwoStringsConstructorException.ERROR_CODE,
             ExceptionWithThrowableConstructorException.ERROR_CODE,
             ExceptionWithStringAndThrowableConstructorException.ERROR_CODE,
-            ExceptionWithExceptionConstructorException.ERROR_CODE));
+            ExceptionWithExceptionConstructorException.ERROR_CODE,
+            MultipleFieldsException.ERROR_CODE));
   }
 
   @Test
@@ -276,7 +277,7 @@ public class ReflectionErrorDecoderTest {
   @Test
   public void testMultipleFieldsException() throws Exception {
     ServiceExceptionErrorDecoder errorDecoder =
-            new ServiceExceptionErrorDecoder(TestApiClassWithPlainExceptions.class);
+            new ServiceExceptionErrorDecoder(TestApiClassWithPlainExceptions.class, true);
     Map<String, Object> responseAsMap = new HashMap<>();
 
     responseAsMap.put("errorCode", MultipleFieldsException.ERROR_CODE);

--- a/src/test/java/com/coveo/feign/ReflectionErrorDecoderTestClasses.java
+++ b/src/test/java/com/coveo/feign/ReflectionErrorDecoderTestClasses.java
@@ -13,6 +13,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import feign.RequestLine;
 
 public class ReflectionErrorDecoderTestClasses {
+  public interface TestApiWithExceptionsWithMultipleFields {
+    @RequestLine(value = "")
+    void soManyFields() throws MultipleFieldsException;
+  }
+
   public interface TestApiWithExceptionsWithMultipleConstructors {
     @RequestLine(value = "")
     void soManyConstructors() throws MultipleConstructorsException;
@@ -81,9 +86,6 @@ public class ReflectionErrorDecoderTestClasses {
     @GetMapping("")
     void methodWithGetMappingAndExceptionConstructorException()
         throws ExceptionWithExceptionConstructorException;
-
-    @GetMapping("")
-    void methodWithMultipleFieldsException() throws MultipleFieldsException;
   }
 
   public interface TestApiClassWithSpringAnnotations {

--- a/src/test/java/com/coveo/feign/ReflectionErrorDecoderTestClasses.java
+++ b/src/test/java/com/coveo/feign/ReflectionErrorDecoderTestClasses.java
@@ -1,5 +1,8 @@
 package com.coveo.feign;
 
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -78,6 +81,9 @@ public class ReflectionErrorDecoderTestClasses {
     @GetMapping("")
     void methodWithGetMappingAndExceptionConstructorException()
         throws ExceptionWithExceptionConstructorException;
+
+    @GetMapping("")
+    void methodWithMultipleFieldsException() throws MultipleFieldsException;
   }
 
   public interface TestApiClassWithSpringAnnotations {
@@ -302,6 +308,62 @@ public class ReflectionErrorDecoderTestClasses {
 
     public MultipleConstructorsWithOnlyThrowableArgumentsException(Throwable cause) {
       super(ERROR_CODE, "", cause);
+    }
+  }
+
+  public static class MultipleFieldsException extends ServiceException {
+    private static final long serialVersionUID = 1L;
+    public static final String ERROR_CODE = "MANY_FIELDS";
+
+    private Integer field1;
+    private Double field2;
+
+    private String field3;
+    private List<String> field4;
+    private Map<String, Object> field5;
+
+    public MultipleFieldsException() {
+      super(ERROR_CODE);
+    };
+
+    Integer getField1() {
+      return field1;
+    }
+
+    Double getField2() {
+      return field2;
+    }
+
+    String getField3() {
+      return field3;
+    }
+
+    List<String> getField4() {
+      return field4;
+    }
+
+    Map<String, Object> getField5() {
+      return field5;
+    }
+
+    public void setField1(Integer field1) {
+      this.field1 = field1;
+    }
+
+    public void setField2(Double field2) {
+      this.field2 = field2;
+    }
+
+    public void setField3(String field3) {
+      this.field3 = field3;
+    }
+
+    public void setField4(List<String> field4) {
+      this.field4 = field4;
+    }
+
+    public void setField5(Map<String, Object> field5) {
+      this.field5 = field5;
     }
   }
 }

--- a/src/test/java/com/coveo/feign/ServiceExceptionErrorDecoder.java
+++ b/src/test/java/com/coveo/feign/ServiceExceptionErrorDecoder.java
@@ -12,8 +12,17 @@ public class ServiceExceptionErrorDecoder
     super(apiClass, ErrorCodeAndMessage.class, ServiceException.class, "com.coveo.feign");
   }
 
+  public ServiceExceptionErrorDecoder(Class<?> apiClass, boolean isMultipleFieldsEnabled) {
+    super(apiClass, ErrorCodeAndMessage.class, ServiceException.class, "com.coveo.feign", isMultipleFieldsEnabled);
+  }
+
   public ServiceExceptionErrorDecoder(Class<?> apiClass, ErrorDecoder fallbackErrorDecoder) {
     super(apiClass, ErrorCodeAndMessage.class, ServiceException.class, "com.coveo.feign");
+    setFallbackErrorDecoder(fallbackErrorDecoder);
+  }
+
+  public ServiceExceptionErrorDecoder(Class<?> apiClass, ErrorDecoder fallbackErrorDecoder, boolean isMultipleFieldsEnabled) {
+    super(apiClass, ErrorCodeAndMessage.class, ServiceException.class, "com.coveo.feign", isMultipleFieldsEnabled);
     setFallbackErrorDecoder(fallbackErrorDecoder);
   }
 

--- a/src/test/java/com/coveo/feign/ServiceExceptionErrorDecoder.java
+++ b/src/test/java/com/coveo/feign/ServiceExceptionErrorDecoder.java
@@ -12,17 +12,8 @@ public class ServiceExceptionErrorDecoder
     super(apiClass, ErrorCodeAndMessage.class, ServiceException.class, "com.coveo.feign");
   }
 
-  public ServiceExceptionErrorDecoder(Class<?> apiClass, boolean isMultipleFieldsEnabled) {
-    super(apiClass, ErrorCodeAndMessage.class, ServiceException.class, "com.coveo.feign", isMultipleFieldsEnabled);
-  }
-
   public ServiceExceptionErrorDecoder(Class<?> apiClass, ErrorDecoder fallbackErrorDecoder) {
     super(apiClass, ErrorCodeAndMessage.class, ServiceException.class, "com.coveo.feign");
-    setFallbackErrorDecoder(fallbackErrorDecoder);
-  }
-
-  public ServiceExceptionErrorDecoder(Class<?> apiClass, ErrorDecoder fallbackErrorDecoder, boolean isMultipleFieldsEnabled) {
-    super(apiClass, ErrorCodeAndMessage.class, ServiceException.class, "com.coveo.feign", isMultipleFieldsEnabled);
     setFallbackErrorDecoder(fallbackErrorDecoder);
   }
 


### PR DESCRIPTION
The Feign Reflection Error Decoder currently does not support the deserialization of exceptions with multiple fields. For example, an exception may not return only the message, but other details such as the context in which it was thrown. The current implementation uses reflection to set `detailMessage`, but other fields are determined by the one-time-defined `getSupportedConstructorArgumentInstances()`.

In this PR, I added `getExceptionByObjectMapperAndReflection()` which reuses `JacksonDecoder` to deserialize the response into an exception. Reflection is still used to set `detailMessage`.

In order not to break compatibility, this functionality is enabled only if `setMultipleFieldsEnabled()` is called after initialization. If disabled, the old way of using constructors to create the exception is used. I also didn't want to clutter the code by adding  a new `boolean` parameter to each constructor.

`getExceptionByObjectMapperAndReflection()` can fully replace `getExceptionByReflection()`; I was experimenting and all the unit tests pass. However, I am not sure if there are some use cases whereby using the `JacksonDecoder` will break any existing functionality, so I decided to implement the `boolean` switch instead.

One catch of this is that a no-args constructor needs to be created for the exception, even if one prefers an all-args constructor or something else. Technically, any constructor that fits `getSupportedConstructorArgumentInstances()` would do the job, but the no-args constructor is the simplest.