### PR TITLE
Allow classes without the proper interface to still work on JDK < 16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.coveo</groupId>
     <artifactId>feign-error-decoder</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
     <packaging>jar</packaging>
 
     <name>Feign Reflection Error Decoder</name>

--- a/src/test/java/com/coveo/feign/BaseServiceException.java
+++ b/src/test/java/com/coveo/feign/BaseServiceException.java
@@ -1,0 +1,30 @@
+package com.coveo.feign;
+
+public abstract class BaseServiceException extends Exception {
+  private static final long serialVersionUID = 4116691862956368612L;
+  private final String errorCode;
+
+  protected BaseServiceException(String errorCode) {
+    this.errorCode = errorCode;
+  }
+
+  protected BaseServiceException(String errorCode, Throwable e) {
+    super(e);
+    this.errorCode = errorCode;
+  }
+
+  protected BaseServiceException(String errorCode, String message) {
+    super(message);
+    this.errorCode = errorCode;
+  }
+
+  protected BaseServiceException(String errorCode, String message, Throwable innerException) {
+    super(message, innerException);
+    this.errorCode = errorCode;
+  }
+
+  public String getErrorCode() {
+    return errorCode;
+  }
+
+}

--- a/src/test/java/com/coveo/feign/ReflectionErrorDecoderTestClasses.java
+++ b/src/test/java/com/coveo/feign/ReflectionErrorDecoderTestClasses.java
@@ -80,6 +80,9 @@ public class ReflectionErrorDecoderTestClasses {
     @GetMapping("")
     void methodWithGetMappingAndExceptionConstructorException()
         throws ExceptionWithExceptionConstructorException;
+
+    @RequestLine("")
+    void methodWithExceptionWithoutInterface() throws ConcreteSubServiceExceptionWithoutInterface;
   }
 
   public interface TestApiClassWithSpringAnnotations {
@@ -149,6 +152,24 @@ public class ReflectionErrorDecoderTestClasses {
     public void setExceptionMessage(String detailMessage) {
       this.detailMessage = detailMessage;
     }
+  }
+
+  public static class AdditionalNotInterfacedRuntimeException extends AbstractAdditionalRuntimeException {
+    private static final long serialVersionUID = 1L;
+    public static final String ERROR_CODE = "DOYOUEVENIMPLEMENTBRO?";
+    public static final String ERROR_MESSAGE = "PANICATTHEDISCO";
+
+    private String detailMessage;
+
+    public AdditionalNotInterfacedRuntimeException() {
+      super(ERROR_CODE, ERROR_MESSAGE);
+    }
+
+    @Override
+    public String getMessage() {
+      return detailMessage == null ? super.getMessage() : detailMessage;
+    }
+
   }
 
   public abstract static class AbstractAdditionalRuntimeException extends RuntimeException {
@@ -269,6 +290,11 @@ public class ReflectionErrorDecoderTestClasses {
     public ConcreteSubServiceException() {
       super(ERROR_CODE);
     }
+  }
+
+  public static class ConcreteSubServiceExceptionWithoutInterface extends ServiceExceptionWithoutInterface {
+    public static final String ERROR_CODE = "I WISH I HAD A PROPER INTERFACE";
+    public ConcreteSubServiceExceptionWithoutInterface() { super(ERROR_CODE);}
   }
 
   public static class DuplicateErrorCodeServiceException extends ServiceException {

--- a/src/test/java/com/coveo/feign/ServiceException.java
+++ b/src/test/java/com/coveo/feign/ServiceException.java
@@ -2,41 +2,33 @@ package com.coveo.feign;
 
 import com.coveo.feign.annotation.ExceptionMessageSetter;
 
-public abstract class ServiceException extends Exception implements ExceptionMessageSetter {
+public abstract class ServiceException extends BaseServiceException implements ExceptionMessageSetter {
   private static final long serialVersionUID = 4116691862956368612L;
-  private String errorCode;
   private String detailMessage;
 
   protected ServiceException(String errorCode) {
-    this.errorCode = errorCode;
+    super(errorCode);
   }
 
   protected ServiceException(String errorCode, Throwable e) {
-    super(e);
-    this.errorCode = errorCode;
+    super(errorCode, e);
   }
 
   protected ServiceException(String errorCode, String message) {
-    super(message);
-    this.errorCode = errorCode;
+    super(errorCode, message);
   }
 
   protected ServiceException(String errorCode, String message, Throwable innerException) {
-    super(message, innerException);
-    this.errorCode = errorCode;
-  }
-
-  public String getErrorCode() {
-    return errorCode;
-  }
-
-  @Override
-  public String getMessage() {
-    return detailMessage == null ? super.getMessage() : detailMessage;
+    super(errorCode, message, innerException);
   }
 
   @Override
   public void setExceptionMessage(String detailMessage) {
     this.detailMessage = detailMessage;
+  }
+
+  @Override
+  public String getMessage() {
+    return detailMessage == null ? super.getMessage() : detailMessage;
   }
 }

--- a/src/test/java/com/coveo/feign/ServiceExceptionErrorDecoder.java
+++ b/src/test/java/com/coveo/feign/ServiceExceptionErrorDecoder.java
@@ -6,19 +6,19 @@ import static com.coveo.feign.ReflectionErrorDecoderTestClasses.*;
 import feign.codec.ErrorDecoder;
 
 public class ServiceExceptionErrorDecoder
-    extends ReflectionErrorDecoder<ErrorCodeAndMessage, ServiceException> {
+    extends ReflectionErrorDecoder<ErrorCodeAndMessage, BaseServiceException> {
 
   public ServiceExceptionErrorDecoder(Class<?> apiClass) {
-    super(apiClass, ErrorCodeAndMessage.class, ServiceException.class, "com.coveo.feign");
+    super(apiClass, ErrorCodeAndMessage.class, BaseServiceException.class, "com.coveo.feign");
   }
 
   public ServiceExceptionErrorDecoder(Class<?> apiClass, ErrorDecoder fallbackErrorDecoder) {
-    super(apiClass, ErrorCodeAndMessage.class, ServiceException.class, "com.coveo.feign");
+    super(apiClass, ErrorCodeAndMessage.class, BaseServiceException.class, "com.coveo.feign");
     setFallbackErrorDecoder(fallbackErrorDecoder);
   }
 
   @Override
-  protected String getKeyFromException(ServiceException exception) {
+  protected String getKeyFromException(BaseServiceException exception) {
     return exception.getErrorCode();
   }
 
@@ -39,6 +39,11 @@ public class ServiceExceptionErrorDecoder
         AdditionalRuntimeException.ERROR_CODE,
         new ThrownExceptionDetails<RuntimeException>()
             .withClazz(AdditionalRuntimeException.class)
-            .withExceptionSupplier(() -> new AdditionalRuntimeException()));
+            .withExceptionSupplier(AdditionalRuntimeException::new));
+    runtimeExceptionsThrown.put(
+            AdditionalNotInterfacedRuntimeException.ERROR_CODE,
+            new ThrownExceptionDetails<RuntimeException>()
+                    .withClazz(AdditionalNotInterfacedRuntimeException.class)
+                    .withExceptionSupplier(AdditionalNotInterfacedRuntimeException::new));
   }
 }

--- a/src/test/java/com/coveo/feign/ServiceExceptionWithoutInterface.java
+++ b/src/test/java/com/coveo/feign/ServiceExceptionWithoutInterface.java
@@ -1,0 +1,10 @@
+package com.coveo.feign;
+
+
+public abstract class ServiceExceptionWithoutInterface extends BaseServiceException {
+  private static final long serialVersionUID = 4116691862956368612L;
+
+  protected ServiceExceptionWithoutInterface(String errorCode) {
+    super(errorCode);
+  }
+}


### PR DESCRIPTION
To facilitate migration for people transitionning from the version 1 to version 2, the mechanism to set the detail message reflectively has been added back as a fallback mechanism. **This fallback mechanism is only available while running on JDK < 16**.
