### PR TITLE
Improve logging and fix CI

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,7 +18,7 @@ jobs:
           distribution: 'temurin'
           cache: maven
       - name: Build with Maven with jdk 8
-        run: mvn -ntp compile test-compile --file pom.xml
+        run: mvn -ntp clean compile test-compile --file pom.xml
       - name: Run tests with jdk 8
         run: mvn -ntp -fae test --file pom.xml
       - name: Set up JDK 17
@@ -28,6 +28,6 @@ jobs:
           distribution: 'temurin'
           cache: maven
       - name: Build with Maven with jdk 17
-        run: mvn -ntp compile test-compile --file pom.xml
+        run: mvn -ntp clean compile test-compile --file pom.xml
       - name: Run tests with jdk 17
         run: mvn -fae -ntp test --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,7 +18,9 @@ jobs:
           distribution: 'temurin'
           cache: maven
       - name: Build with Maven with jdk 8
-        run: mvn -B verify --file pom.xml
+        run: mvn -ntp compile test-compile --file pom.xml
+      - name: Run tests with jdk 8
+        run: mvn -ntp -fae test --file pom.xml
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
@@ -26,4 +28,6 @@ jobs:
           distribution: 'temurin'
           cache: maven
       - name: Build with Maven with jdk 17
-        run: mvn -B verify --file pom.xml
+        run: mvn -ntp compile test-compile --file pom.xml
+      - name: Run tests with jdk 17
+        run: mvn -fae -ntp test --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,21 @@
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+          cache: maven
+      - name: Build with Maven
+        run: mvn -B verify --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,5 +17,13 @@ jobs:
           java-version: '8'
           distribution: 'temurin'
           cache: maven
-      - name: Build with Maven
+      - name: Build with Maven with jdk 8
+        run: mvn -B verify --file pom.xml
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+      - name: Build with Maven with jdk 17
         run: mvn -B verify --file pom.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: java
-
-jdk: 
-  - openjdk8
-
-cache: 
-  directories:
-    - "$HOME/.m2/repository"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![Build Status](https://travis-ci.org/coveo/feign-error-decoder.svg?branch=master)](https://travis-ci.org/coveo/feign-error-decoder)
 [![MIT license](http://img.shields.io/badge/license-MIT-brightgreen.svg)](https://github.com/coveo/feign-error-decoder/blob/master/LICENSE)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.coveo/feign-error-decoder/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.coveo/feign-error-decoder)
 
@@ -17,7 +16,7 @@ The plugin is available on Maven Central :
     <dependency>
       <groupId>com.coveo</groupId>
       <artifactId>feign-error-decoder</artifactId>
-      <version>2.0.0</version>
+      <version>2.2.0</version>
     </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.coveo</groupId>
     <artifactId>feign-error-decoder</artifactId>
-    <version>2.1.0</version>
+    <version>2.2.0</version>
     <packaging>jar</packaging>
 
     <name>Feign Reflection Error Decoder</name>

--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,23 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M7</version>
+                <version>3.0.0</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>me.fabriciorby</groupId>
+                        <artifactId>maven-surefire-junit5-tree-reporter</artifactId>
+                        <version>1.1.0</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <reportFormat>plain</reportFormat>
+                    <consoleOutputReporter>
+                        <disable>true</disable>
+                    </consoleOutputReporter>
+                    <statelessTestsetInfoReporter
+                            implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporterUnicode">
+                    </statelessTestsetInfoReporter>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/coveo/feign/ReflectionErrorDecoder.java
+++ b/src/main/java/com/coveo/feign/ReflectionErrorDecoder.java
@@ -135,7 +135,10 @@ public abstract class ReflectionErrorDecoder<T, S extends Exception> implements 
       detailMessageField = Throwable.class.getDeclaredField("detailMessage");
       detailMessageField.setAccessible(true);
     } catch (Exception e) {
-      logger.debug("Unable to directly set the detailMessage, make sure exception do implement {}", baseExceptionClass.getName());
+      logger.debug(
+          "Unable to set the detailMessage via reflection, make sure the base exception do implement '{}'. Error message: '{}'.",
+          ExceptionMessageSetter.class.getName(),
+          e.getMessage());
       detailMessageField = null;
     }
 
@@ -184,7 +187,7 @@ public abstract class ReflectionErrorDecoder<T, S extends Exception> implements 
       ((ExceptionMessageSetter) runtimeExceptionToBeThrown)
           .setExceptionMessage(getMessageFromResponse(apiResponse));
     } else {
-      if(detailMessageField != null) {
+      if (detailMessageField != null) {
         detailMessageField.set(runtimeExceptionToBeThrown, getMessageFromResponse(apiResponse));
       }
     }
@@ -198,7 +201,7 @@ public abstract class ReflectionErrorDecoder<T, S extends Exception> implements 
       ((ExceptionMessageSetter) exceptionToBeThrown)
           .setExceptionMessage(getMessageFromResponse(apiResponse));
     } else {
-      if(detailMessageField != null) {
+      if (detailMessageField != null) {
         detailMessageField.set(exceptionToBeThrown, getMessageFromResponse(apiResponse));
       }
     }
@@ -244,11 +247,13 @@ public abstract class ReflectionErrorDecoder<T, S extends Exception> implements 
                 existingExceptionDetails.getClazz().getName()));
       }
 
-      if (!exceptionMessageHandlingLogged
+      if (detailMessageField == null
+          && !exceptionMessageHandlingLogged
           && !ExceptionMessageSetter.class.isAssignableFrom(clazz)) {
         logger.warn(
-            "The class '{}' or its superclass(es) do not implement ExceptionMessageSetter, therefore the Throwable detailMessage field will not be set. This will be only logged once.",
-            clazz);
+            "The class '{}' or its superclass(es) do not implement '{}', therefore the Throwable detailMessage field will not be set. This will be only logged once.",
+            clazz,
+            ExceptionMessageSetter.class.getName());
         exceptionMessageHandlingLogged = true;
       }
     }

--- a/src/test/java/com/coveo/feign/BaseServiceException.java
+++ b/src/test/java/com/coveo/feign/BaseServiceException.java
@@ -26,5 +26,4 @@ public abstract class BaseServiceException extends Exception {
   public String getErrorCode() {
     return errorCode;
   }
-
 }

--- a/src/test/java/com/coveo/feign/ReflectionErrorDecoderTest.java
+++ b/src/test/java/com/coveo/feign/ReflectionErrorDecoderTest.java
@@ -222,12 +222,13 @@ public class ReflectionErrorDecoderTest {
   }
 
   @Test
-  @EnabledForJreRange(max=JRE.JAVA_15)
+  @EnabledForJreRange(max = JRE.JAVA_15)
   public void testDecodeThrownSubAbstractExceptionWithoutInterface() throws Exception {
     ServiceExceptionErrorDecoder errorDecoder =
-            new ServiceExceptionErrorDecoder(TestApiClassWithPlainExceptions.class);
+        new ServiceExceptionErrorDecoder(TestApiClassWithPlainExceptions.class);
     Response response =
-            getResponseWithErrorCode(ConcreteSubServiceExceptionWithoutInterface.ERROR_CODE, DUMMY_MESSAGE);
+        getResponseWithErrorCode(
+            ConcreteSubServiceExceptionWithoutInterface.ERROR_CODE, DUMMY_MESSAGE);
 
     Exception exception = errorDecoder.decode("", response);
 
@@ -236,12 +237,14 @@ public class ReflectionErrorDecoderTest {
   }
 
   @Test
-  @EnabledForJreRange(min=JRE.JAVA_16)
-  public void testDecodeThrownSubAbstractExceptionWithoutInterfaceShouldDoNothing() throws Exception {
+  @EnabledForJreRange(min = JRE.JAVA_16)
+  public void testDecodeThrownSubAbstractExceptionWithoutInterfaceShouldDoNothing()
+      throws Exception {
     ServiceExceptionErrorDecoder errorDecoder =
-            new ServiceExceptionErrorDecoder(TestApiClassWithPlainExceptions.class);
+        new ServiceExceptionErrorDecoder(TestApiClassWithPlainExceptions.class);
     Response response =
-            getResponseWithErrorCode(ConcreteSubServiceExceptionWithoutInterface.ERROR_CODE, DUMMY_MESSAGE);
+        getResponseWithErrorCode(
+            ConcreteSubServiceExceptionWithoutInterface.ERROR_CODE, DUMMY_MESSAGE);
 
     Exception exception = errorDecoder.decode("", response);
 
@@ -293,12 +296,12 @@ public class ReflectionErrorDecoderTest {
   }
 
   @Test
-  @EnabledForJreRange(max=JRE.JAVA_15)
+  @EnabledForJreRange(max = JRE.JAVA_15)
   public void testAdditionalRuntimeExceptionWithoutInterface() throws Exception {
     ServiceExceptionErrorDecoder errorDecoder =
-            new ServiceExceptionErrorDecoder(TestApiClassWithPlainExceptions.class);
+        new ServiceExceptionErrorDecoder(TestApiClassWithPlainExceptions.class);
     Response response =
-            getResponseWithErrorCode(AdditionalNotInterfacedRuntimeException.ERROR_CODE, DUMMY_MESSAGE);
+        getResponseWithErrorCode(AdditionalNotInterfacedRuntimeException.ERROR_CODE, DUMMY_MESSAGE);
 
     Exception exception = errorDecoder.decode("", response);
 
@@ -307,17 +310,18 @@ public class ReflectionErrorDecoderTest {
   }
 
   @Test
-  @EnabledForJreRange(min=JRE.JAVA_16)
+  @EnabledForJreRange(min = JRE.JAVA_16)
   public void testAdditionalRuntimeExceptionWithoutInterfaceShouldDoNothing() throws Exception {
     ServiceExceptionErrorDecoder errorDecoder =
-            new ServiceExceptionErrorDecoder(TestApiClassWithPlainExceptions.class);
+        new ServiceExceptionErrorDecoder(TestApiClassWithPlainExceptions.class);
     Response response =
-            getResponseWithErrorCode(AdditionalNotInterfacedRuntimeException.ERROR_CODE, DUMMY_MESSAGE);
+        getResponseWithErrorCode(AdditionalNotInterfacedRuntimeException.ERROR_CODE, DUMMY_MESSAGE);
 
     Exception exception = errorDecoder.decode("", response);
 
     assertThat(exception).isInstanceOf(AdditionalNotInterfacedRuntimeException.class);
-    assertThat(exception.getMessage()).isEqualTo(AdditionalNotInterfacedRuntimeException.ERROR_MESSAGE);
+    assertThat(exception.getMessage())
+        .isEqualTo(AdditionalNotInterfacedRuntimeException.ERROR_MESSAGE);
   }
 
   @Test

--- a/src/test/java/com/coveo/feign/ReflectionErrorDecoderTestClasses.java
+++ b/src/test/java/com/coveo/feign/ReflectionErrorDecoderTestClasses.java
@@ -154,7 +154,8 @@ public class ReflectionErrorDecoderTestClasses {
     }
   }
 
-  public static class AdditionalNotInterfacedRuntimeException extends AbstractAdditionalRuntimeException {
+  public static class AdditionalNotInterfacedRuntimeException
+      extends AbstractAdditionalRuntimeException {
     private static final long serialVersionUID = 1L;
     public static final String ERROR_CODE = "DOYOUEVENIMPLEMENTBRO?";
     public static final String ERROR_MESSAGE = "PANICATTHEDISCO";
@@ -169,7 +170,6 @@ public class ReflectionErrorDecoderTestClasses {
     public String getMessage() {
       return detailMessage == null ? super.getMessage() : detailMessage;
     }
-
   }
 
   public abstract static class AbstractAdditionalRuntimeException extends RuntimeException {
@@ -292,9 +292,13 @@ public class ReflectionErrorDecoderTestClasses {
     }
   }
 
-  public static class ConcreteSubServiceExceptionWithoutInterface extends ServiceExceptionWithoutInterface {
+  public static class ConcreteSubServiceExceptionWithoutInterface
+      extends ServiceExceptionWithoutInterface {
     public static final String ERROR_CODE = "I WISH I HAD A PROPER INTERFACE";
-    public ConcreteSubServiceExceptionWithoutInterface() { super(ERROR_CODE);}
+
+    public ConcreteSubServiceExceptionWithoutInterface() {
+      super(ERROR_CODE);
+    }
   }
 
   public static class DuplicateErrorCodeServiceException extends ServiceException {

--- a/src/test/java/com/coveo/feign/ServiceException.java
+++ b/src/test/java/com/coveo/feign/ServiceException.java
@@ -2,7 +2,8 @@ package com.coveo.feign;
 
 import com.coveo.feign.annotation.ExceptionMessageSetter;
 
-public abstract class ServiceException extends BaseServiceException implements ExceptionMessageSetter {
+public abstract class ServiceException extends BaseServiceException
+    implements ExceptionMessageSetter {
   private static final long serialVersionUID = 4116691862956368612L;
   private String detailMessage;
 

--- a/src/test/java/com/coveo/feign/ServiceExceptionErrorDecoder.java
+++ b/src/test/java/com/coveo/feign/ServiceExceptionErrorDecoder.java
@@ -41,9 +41,9 @@ public class ServiceExceptionErrorDecoder
             .withClazz(AdditionalRuntimeException.class)
             .withExceptionSupplier(AdditionalRuntimeException::new));
     runtimeExceptionsThrown.put(
-            AdditionalNotInterfacedRuntimeException.ERROR_CODE,
-            new ThrownExceptionDetails<RuntimeException>()
-                    .withClazz(AdditionalNotInterfacedRuntimeException.class)
-                    .withExceptionSupplier(AdditionalNotInterfacedRuntimeException::new));
+        AdditionalNotInterfacedRuntimeException.ERROR_CODE,
+        new ThrownExceptionDetails<RuntimeException>()
+            .withClazz(AdditionalNotInterfacedRuntimeException.class)
+            .withExceptionSupplier(AdditionalNotInterfacedRuntimeException::new));
   }
 }

--- a/src/test/java/com/coveo/feign/ServiceExceptionWithoutInterface.java
+++ b/src/test/java/com/coveo/feign/ServiceExceptionWithoutInterface.java
@@ -1,6 +1,5 @@
 package com.coveo.feign;
 
-
 public abstract class ServiceExceptionWithoutInterface extends BaseServiceException {
   private static final long serialVersionUID = 4116691862956368612L;
 


### PR DESCRIPTION
The logging message when not being able to set accessible the `detailMessage` field was wrong so that's not fixed. The WARN is also not logged when the base exception implements `ExceptionMessageSetter`.

Formatting has been fixed, last PR didn't run it it seems.