### PR TITLE
Support nested exception hierarchies without an abstract base class

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The plugin is available on Maven Central :
     <dependency>
       <groupId>com.coveo</groupId>
       <artifactId>feign-error-decoder</artifactId>
-      <version>3.0.0</version>
+      <version>3.1.0</version>
     </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.coveo</groupId>
     <artifactId>feign-error-decoder</artifactId>
-    <version>3.0.0</version>
+    <version>3.1.0</version>
     <packaging>jar</packaging>
 
     <name>Feign Reflection Error Decoder</name>

--- a/src/main/java/com/coveo/feign/ReflectionErrorDecoder.java
+++ b/src/main/java/com/coveo/feign/ReflectionErrorDecoder.java
@@ -173,7 +173,7 @@ public abstract class ReflectionErrorDecoder<T, S extends Exception> implements 
       throws InstantiationException, IllegalAccessException, InvocationTargetException {
     for (Class<?> clazz : thrownExceptionsClasses) {
       if (baseExceptionClass.isAssignableFrom(clazz)) {
-        if (Modifier.isAbstract(clazz.getModifiers())) {
+        if (!classHierarchySupplier.getSubClasses(clazz, basePackage).isEmpty()) {
           extractExceptionInfoFromSubClasses(classHierarchySupplier, clazz);
         } else {
           extractExceptionInfo((Class<? extends S>) clazz);

--- a/src/test/java/com/coveo/feign/ReflectionErrorDecoderTest.java
+++ b/src/test/java/com/coveo/feign/ReflectionErrorDecoderTest.java
@@ -22,6 +22,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.coveo.feign.ReflectionErrorDecoderTestClasses.AdditionalNotInterfacedRuntimeException;
 import com.coveo.feign.ReflectionErrorDecoderTestClasses.AdditionalRuntimeException;
+import com.coveo.feign.ReflectionErrorDecoderTestClasses.BaseNotAbstractException;
+import com.coveo.feign.ReflectionErrorDecoderTestClasses.ChildOfBaseNotAbstractException;
 import com.coveo.feign.ReflectionErrorDecoderTestClasses.ConcreteServiceException;
 import com.coveo.feign.ReflectionErrorDecoderTestClasses.ConcreteSubServiceException;
 import com.coveo.feign.ReflectionErrorDecoderTestClasses.ConcreteSubServiceExceptionWithoutInterface;
@@ -32,9 +34,11 @@ import com.coveo.feign.ReflectionErrorDecoderTestClasses.ExceptionWithStringAndT
 import com.coveo.feign.ReflectionErrorDecoderTestClasses.ExceptionWithStringConstructorException;
 import com.coveo.feign.ReflectionErrorDecoderTestClasses.ExceptionWithThrowableConstructorException;
 import com.coveo.feign.ReflectionErrorDecoderTestClasses.ExceptionWithTwoStringsConstructorException;
+import com.coveo.feign.ReflectionErrorDecoderTestClasses.GrandChildOfBaseNotAbstractException;
 import com.coveo.feign.ReflectionErrorDecoderTestClasses.MultipleConstructorsException;
 import com.coveo.feign.ReflectionErrorDecoderTestClasses.MultipleConstructorsWithOnlyThrowableArgumentsException;
 import com.coveo.feign.ReflectionErrorDecoderTestClasses.TestApiClassWithDuplicateErrorCodeException;
+import com.coveo.feign.ReflectionErrorDecoderTestClasses.TestApiClassWithInheritedButNotAbstractExceptions;
 import com.coveo.feign.ReflectionErrorDecoderTestClasses.TestApiClassWithInheritedExceptions;
 import com.coveo.feign.ReflectionErrorDecoderTestClasses.TestApiClassWithNoErrorCodeServiceException;
 import com.coveo.feign.ReflectionErrorDecoderTestClasses.TestApiClassWithPlainExceptions;
@@ -137,6 +141,19 @@ public class ReflectionErrorDecoderTest {
     assertThat(exceptionsThrown.keySet())
         .containsExactly(
             ConcreteServiceException.ERROR_CODE, ConcreteSubServiceException.ERROR_CODE);
+  }
+
+  @Test
+  public void testWithNotAbstractInheritedExceptions() throws Exception {
+    Map<String, ThrownExceptionDetails<ServiceException>> exceptionsThrown =
+        getExceptionsThrownMapFromErrorDecoder(
+            TestApiClassWithInheritedButNotAbstractExceptions.class);
+
+    assertThat(exceptionsThrown.keySet())
+        .containsExactly(
+            BaseNotAbstractException.ERROR_CODE,
+            ChildOfBaseNotAbstractException.ERROR_CODE,
+            GrandChildOfBaseNotAbstractException.ERROR_CODE);
   }
 
   @Test

--- a/src/test/java/com/coveo/feign/ReflectionErrorDecoderTestClasses.java
+++ b/src/test/java/com/coveo/feign/ReflectionErrorDecoderTestClasses.java
@@ -111,6 +111,11 @@ public class ReflectionErrorDecoderTestClasses {
     void methodWithAbstractException() throws AbstractServiceException;
   }
 
+  public interface TestApiClassWithInheritedButNotAbstractExceptions {
+    @RequestLine("")
+    void methodWithInheritedNotAbstractException() throws BaseNotAbstractException;
+  }
+
   public interface TestApiClassWithDuplicateErrorCodeException {
     @RequestLine("")
     void methodWithDuplicateErrorCodeException()
@@ -347,6 +352,42 @@ public class ReflectionErrorDecoderTestClasses {
 
     public MultipleConstructorsWithOnlyThrowableArgumentsException(Throwable cause) {
       super(ERROR_CODE, "", cause);
+    }
+  }
+
+  public static class BaseNotAbstractException extends ServiceException {
+    private static final long serialVersionUID = 1L;
+    public static final String ERROR_CODE = "ABSTRACT CONSIDERED HARMFUL";
+
+    public BaseNotAbstractException(Throwable e) {
+      super(ERROR_CODE, e);
+    }
+
+    protected BaseNotAbstractException(String errorCode, String message) {
+      super(errorCode, message);
+    }
+  }
+
+  public static class ChildOfBaseNotAbstractException extends BaseNotAbstractException {
+    private static final long serialVersionUID = 1L;
+    public static final String ERROR_CODE = "THIS IS PERFECTLY ACCEPTABLE";
+
+    public ChildOfBaseNotAbstractException(String message) {
+      super(ERROR_CODE, message);
+    }
+
+    protected ChildOfBaseNotAbstractException(String errorCode, String message) {
+      super(errorCode, message);
+    }
+  }
+
+  public static class GrandChildOfBaseNotAbstractException extends ChildOfBaseNotAbstractException {
+    private static final long serialVersionUID = 1L;
+    public static final String ERROR_CODE =
+        "THIS IS ARGUABLY A BAD PRACTICE BUT IT SHOULD STILL WORK";
+
+    public GrandChildOfBaseNotAbstractException(String message) {
+      super(ERROR_CODE, message);
     }
   }
 }


### PR DESCRIPTION
This change allows the error decoder to properly handle exceptions that are not abstract but still have children.

I ran the whole test suite with various JREs (11, 17, 21) and all tests pass.