### PR TITLE
Improve throwable instance used as argument in exception construction

### DIFF
--- a/src/main/java/com/coveo/feign/ReflectionErrorDecoder.java
+++ b/src/main/java/com/coveo/feign/ReflectionErrorDecoder.java
@@ -8,7 +8,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,14 +36,7 @@ import feign.jackson.JacksonDecoder;
 public abstract class ReflectionErrorDecoder<T, S extends Exception> implements ErrorDecoder {
   private static final Logger logger = LoggerFactory.getLogger(ReflectionErrorDecoder.class);
 
-  private static final List<Object> SUPPORTED_CONSTRUCTOR_ARGUMENTS =
-      Arrays.asList(
-          "",
-          new Exception(
-              "Not the real cause, this throwable was only used for instantiation by ReflectionErrorDecoder"),
-          new Error(
-              "Not the real cause, this throwable was only used for instantiation by ReflectionErrorDecoder"));
-
+  private static final List<Object> SUPPORTED_CONSTRUCTOR_ARGUMENTS;
   private static Field detailMessageField;
   private static boolean isSpringWebAvailable = ClassUtils.isSpringWebAvailable();
 
@@ -66,6 +58,14 @@ public abstract class ReflectionErrorDecoder<T, S extends Exception> implements 
           e.getMessage());
       detailMessageField = null;
     }
+
+    String message =
+        "Not the real cause, this throwable was only used for instantiation by ReflectionErrorDecoder.";
+    Exception dummyException = new Exception(message);
+    Error dummyError = new Error(message);
+    Stream.of(dummyError, dummyException)
+        .forEach(throwable -> throwable.setStackTrace(new StackTraceElement[0]));
+    SUPPORTED_CONSTRUCTOR_ARGUMENTS = List.of("", dummyException, dummyError);
   }
 
   protected Class<?> apiClass;

--- a/src/main/java/com/coveo/feign/hierarchy/CachedSpringClassHierarchySupplier.java
+++ b/src/main/java/com/coveo/feign/hierarchy/CachedSpringClassHierarchySupplier.java
@@ -50,9 +50,6 @@ public class CachedSpringClassHierarchySupplier implements ClassHierarchySupplie
 
   @Override
   public Set<Class<?>> getSubClasses(Class<?> clazz, String basePackage) {
-    return subClasses
-        .stream()
-        .filter(subClass -> clazz.isAssignableFrom(subClass))
-        .collect(Collectors.toSet());
+    return subClasses.stream().filter(clazz::isAssignableFrom).collect(Collectors.toSet());
   }
 }

--- a/src/test/java/com/coveo/feign/ReflectionErrorDecoderTest.java
+++ b/src/test/java/com/coveo/feign/ReflectionErrorDecoderTest.java
@@ -283,6 +283,23 @@ public class ReflectionErrorDecoderTest {
   }
 
   @Test
+  public void testThrowableArgumentHasNoStackTraceElement() throws Exception {
+    Map<String, ThrownExceptionDetails<ServiceException>> exceptionsThrown =
+        getExceptionsThrownMapFromErrorDecoder(
+            TestApiWithExceptionsWithMultipleConstructorsWithOnlyThrowables.class);
+
+    assertThat(exceptionsThrown.keySet())
+        .containsExactly(MultipleConstructorsWithOnlyThrowableArgumentsException.ERROR_CODE);
+    ThrownExceptionDetails<ServiceException> thrownExceptionDetails =
+        exceptionsThrown.get(MultipleConstructorsWithOnlyThrowableArgumentsException.ERROR_CODE);
+    MultipleConstructorsWithOnlyThrowableArgumentsException exception =
+        (MultipleConstructorsWithOnlyThrowableArgumentsException)
+            thrownExceptionDetails.instantiate();
+    assertThat(exception.getCause()).isNotNull();
+    assertThat(exception.getCause().getStackTrace()).isEmpty();
+  }
+
+  @Test
   public void testBestConstructorIsSelectedWithOnlyThrowablesArgumentConstructors()
       throws Exception {
     Map<String, ThrownExceptionDetails<ServiceException>> exceptionsThrown =


### PR DESCRIPTION
The code already favors a constructor without a throwable so we were already covered here. I removed the stacktrace from it to help the users further.